### PR TITLE
bugfix: generate working `oxid.meta.php`

### DIFF
--- a/src/templates/moduleparent-class-template.html.twig
+++ b/src/templates/moduleparent-class-template.html.twig
@@ -1,11 +1,7 @@
 
 {% if not class.namespace is empty %}
-    namespace {{ class.namespace }} {
-        {% if class.isInterface %}
-            interface
-        {% elseif class.isAbstract %}
-            abstract class
-        {% else %}
-            class
-        {% endif %} {{ class.childClassName }} extends\ {{ class.parentClassName }}
+namespace {{ class.namespace }} {
+    {% if class.isInterface %}interface{% elseif class.isAbstract %}abstract class{% else %}class{% endif %} {{ class.childClassName }} extends \{{ class.parentClassName }}
+    {}
+}
 {% endif %}

--- a/src/templates/phpstorm.meta.html.twig
+++ b/src/templates/phpstorm.meta.html.twig
@@ -1,18 +1,18 @@
 {{ '<?php' }}
 
 /**
-* Used by PhpStorm to map factory methods to classes for code completion, source code analysis, etc.
-*
-* The code is not ever actually executed and it only needed during development when coding with PhpStorm.
-*
-* @see https://confluence.jetbrains.com/display/PhpStorm/PhpStorm+Advanced+Metadata
-*/
+ * Used by PhpStorm to map factory methods to classes for code completion, source code analysis, etc.
+ *
+ * The code is not ever actually executed and it only needed during development when coding with PhpStorm.
+ *
+ * @see https://confluence.jetbrains.com/display/PhpStorm/PhpStorm+Advanced+Metadata
+ */
 
 namespace PHPSTORM_META {
-'override(\oxNew(0), type(0));';
+    override(\oxNew(0), type(0));
 }
 
 // Simulating the iteration in PHP for moduleParentClasses
 {% for class in moduleParentClasses %}
-    {% include 'moduleparent-class-template.html.twig' %}
+{% include 'moduleparent-class-template.html.twig' %}
 {% endfor %}

--- a/tests/Integration/GeneratorTest.php
+++ b/tests/Integration/GeneratorTest.php
@@ -123,7 +123,12 @@ final class GeneratorTest extends TestCase
         );
         $generator->generate();
 
-        $this->assertFileExists(Path::join($this->getVirtualOutputDirectory(), '.phpstorm.meta.php/oxid.meta.php'));
+        $pathToOxidPhpStormMetaPhpOutput = Path::join($this->getVirtualOutputDirectory(), '.phpstorm.meta.php/oxid.meta.php');
+        $this->assertFileExists($pathToOxidPhpStormMetaPhpOutput);
+        $this->assertFileEquals(
+            Path::join($this->getPathToTestData(), 'Valid', 'oxid.meta.php'),
+            $pathToOxidPhpStormMetaPhpOutput
+        );
     }
 
     private function getFactsMock($permissionsForShopRootPath): Facts|MockObject

--- a/tests/Integration/testData/Valid/oxid.meta.php
+++ b/tests/Integration/testData/Valid/oxid.meta.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * Used by PhpStorm to map factory methods to classes for code completion, source code analysis, etc.
+ *
+ * The code is not ever actually executed and it only needed during development when coding with PhpStorm.
+ *
+ * @see https://confluence.jetbrains.com/display/PhpStorm/PhpStorm+Advanced+Metadata
+ */
+
+namespace PHPSTORM_META {
+    override(\oxNew(0), type(0));
+}
+
+// Simulating the iteration in PHP for moduleParentClasses
+
+namespace OxidEsales\TestModule\Model {
+    class User_parent extends \OxidEsales\Eshop\Application\Model\User
+    {}
+}
+
+namespace OxidEsales\TestModule\Model {
+    class Article_parent extends \OxidEsales\Eshop\Application\Model\Article
+    {}
+}


### PR DESCRIPTION
Hey guys,

the current implementation generates completely broken code. 
This patch verifies that the generated `oxid.meta.php` file does actually work again rather than just checking if the file exists.

This adds missing trailing curly-braces to the (abstract) class/interface generated within the twig template along with closing the namespace using a curly brace.

I also reformatted the template so that the output does actually conform most coding-standards.
Let me know if I have to revert the "coding-standard" related changes.